### PR TITLE
Update: Check the `extracted` is an existing directory or not.

### DIFF
--- a/run/pipeline.py
+++ b/run/pipeline.py
@@ -103,6 +103,7 @@ for xml_dump_file in list(glob('/data/xueyou/data/speller/wiki/*.7z')):
   # Stage 6
   # clear 
   print('clear tmp files')
+  check_output_dir('./extracted')
   cmd = f'''rm {global_args['xml_dump']}
   rm -rf stage1 stage3 stage4
   mv {xml_dump_file} extracted


### PR DESCRIPTION
https://github.com/xueyouluo/wiki-error-extract/blob/f15e5ea46e53ba2184ef19a75dd076fd2fdfb04e/run/pipeline.py#L108

This line should mean that there is an `extracted` directory for the processed `xml_dump_file` file (`.7z` suffix).
When applied, the effect here is that the file is **renamed** to `extracted` whenever this line is executed.

![image](https://user-images.githubusercontent.com/9395067/161887424-40c15839-cd7a-431d-b501-8f234ac67dc0.png)

The author may have executed pipeline.py without problems because the directory `extracted` already existed during testing, but the error is reproducible in a newly cloned environment. 
Considering that users like me still want to keep the downloaded files, I submitted a PR to help solve this problem. 